### PR TITLE
add: service order find, find all, pagination implementation

### DIFF
--- a/entities/order.go
+++ b/entities/order.go
@@ -132,9 +132,9 @@ type OrderResponse struct {
 	TruckTypeID uint	`json:"truck_type_id"`
 	TruckType TruckTypeResponse	`json:"truck_type"`
 	OrderPicture string	`json:"order_picture"`
-	TotalVolume string	`json:"total_volume"`
-	TotalWeight string	`json:"total_weight"`
-	Distance string	`json:"distance"`
+	TotalVolume int	`json:"total_volume"`
+	TotalWeight int	`json:"total_weight"`
+	Distance int	`json:"distance"`
 	EstimatedPrice int64	`json:"estimated_price"`
 	FixedPrice int64	`json:"fixed_price"`
 	TransactionID interface{}	`json:"transaction_id"`

--- a/entities/order.go
+++ b/entities/order.go
@@ -8,23 +8,24 @@ import (
 
 type Order struct {
 	gorm.Model
-	DriverID uint
+	DriverID uint `gorm:"default:null"`
 	CustomerID uint
 	DestinationID uint
 	TruckTypeID int
 	OrderPicture string
 	TotalVolume int
 	TotalWeight int
-	Distance int
+	Distance int `gorm:"default:null"`
 	EstimatedPrice int64
-	FixPrice int64
-	TransactionID int64
+	FixPrice int64 `gorm:"default:null"`
+	TransactionID string `gorm:"default:null"`
 	Status string
-	Description string
-	ArrivedPicture string
+	Description string `gorm:"default:null"`
+	ArrivedPicture string `gorm:"default:null"`
 	Destination Destination `gorm:"foreignkey:DestinationID;references:ID"`
 	TruckType TruckType `gorm:"foreignkey:TruckTypeID;references:ID"`
 	Customer User `gorm:"foreignKey:CustomerID;references:ID"`
+	Driver Driver `gorm:"foreignKey:DriverID;references:ID;constraint:OnUpdate:SET NULL,OnDelete:SET NULL"`
 }
 
 type Destination struct {

--- a/entities/user.go
+++ b/entities/user.go
@@ -34,6 +34,8 @@ type Driver struct {
 	VehiclePicture    string
 	User              User      `gorm:"foreignKey:UserID;references:ID"`
 	TruckType         TruckType `gorm:"foreignKey:TruckTypeID;references:ID"`
+	Orders 		 	  []Order 	`gorm:"foreignKey:DriverID;references:ID;constraint:OnUpdate:SET NULL,OnDelete:SET NULL"`
+
 }
 
 // File request: avatar
@@ -117,7 +119,6 @@ type DriverResponse struct {
 	ID                uint              `json:"id"`
 	UserID            string            `json:"user_id"`
 	User              CustomerResponse  `json:"user"`
-	Role              string            `json:"role"`
 	TruckTypeID       uint              `json:"truck_type_id"`
 	TruckType         TruckTypeResponse `json:"truck_type"`
 	KtpFile           string            `json:"ktp_file"`

--- a/entities/user.go
+++ b/entities/user.go
@@ -117,7 +117,7 @@ type UpdateDriverRequest struct {
 
 type DriverResponse struct {
 	ID                uint              `json:"id"`
-	UserID            string            `json:"user_id"`
+	UserID            int               `json:"user_id"`
 	User              CustomerResponse  `json:"user"`
 	TruckTypeID       uint              `json:"truck_type_id"`
 	TruckType         TruckTypeResponse `json:"truck_type"`

--- a/repositories/order/order_repository.go
+++ b/repositories/order/order_repository.go
@@ -32,7 +32,7 @@ func NewOrderRepository(db *gorm.DB) *OrderRepository {
  */
 func (repository OrderRepository) FindAll(limit int, offset int, filters []map[string]string, sorts []map[string]interface{}) ([]entities.Order, error) {
 	order := []entities.Order{}
-	builder := repository.db.Limit(limit).Offset(offset).Preload("Destination").Preload("Customer").Preload("TruckType")
+	builder := repository.db.Limit(limit).Offset(offset).Preload("Destination").Preload("Customer").Preload("Driver").Preload("Driver.TruckType").Preload("TruckType")
 	// Where filters
 	for _, filter := range filters {
 		builder.Where(filter["field"]+" "+filter["operator"]+" ?", filter["value"])
@@ -57,7 +57,7 @@ func (repository OrderRepository) FindAll(limit int, offset int, filters []map[s
  */
 func (repository OrderRepository) Find(id int) (entities.Order, error) {
 	order := entities.Order{}
-	tx := repository.db.Preload("Destination").Preload("Customer").Preload("TruckType").Find(&order, id)
+	tx := repository.db.Preload("Destination").Preload("Customer").Preload("Driver").Preload("Driver.TruckType").Preload("TruckType").Find(&order, id)
 	if tx.Error != nil {
 		return entities.Order{}, web.WebError{Code: 500, DevelopmentMessage: "server error", ProductionMessage: "server error"}
 	} else if tx.RowsAffected <= 0 {
@@ -78,7 +78,7 @@ func (repository OrderRepository) Find(id int) (entities.Order, error) {
  */
 func (repository OrderRepository) FindBy(field string, value string) (entities.Order, error) {
 	order := entities.Order{}
-	tx := repository.db.Preload("Destination").Preload("Customer").Preload("TruckType").Where(field+" = ?", value).First(&order)
+	tx := repository.db.Preload("Destination").Preload("Customer").Preload("Driver").Preload("Driver.TruckType").Preload("TruckType").Where(field+" = ?", value).First(&order)
 	if tx.Error != nil {
 		return entities.Order{}, web.WebError{Code: 500, Message: tx.Error.Error()}
 	} else if tx.RowsAffected <= 0 {
@@ -98,7 +98,7 @@ func (repository OrderRepository) FindBy(field string, value string) (entities.O
  */
 func (repository OrderRepository) FindFirst(filters []map[string]string) (entities.Order, error) {
 	order := entities.Order{}
-	builder := repository.db.Preload("Destination").Preload("Customer").Preload("TruckType")
+	builder := repository.db.Preload("Destination").Preload("Customer").Preload("Driver").Preload("Driver.TruckType").Preload("TruckType")
 	// Where filters
 	for _, filter := range filters {
 		builder.Where(filter["field"]+" "+filter["operator"]+" ?", filter["value"])

--- a/repositories/order/order_repository.go
+++ b/repositories/order/order_repository.go
@@ -32,7 +32,7 @@ func NewOrderRepository(db *gorm.DB) *OrderRepository {
  */
 func (repository OrderRepository) FindAll(limit int, offset int, filters []map[string]string, sorts []map[string]interface{}) ([]entities.Order, error) {
 	order := []entities.Order{}
-	builder := repository.db.Limit(limit).Offset(offset).Preload("Destination").Preload("Customer").Preload("Driver").Preload("Driver.TruckType").Preload("TruckType")
+	builder := repository.db.Limit(limit).Offset(offset).Preload("Destination").Preload("Customer").Preload("Driver").Preload("Driver.TruckType").Preload("Driver.User").Preload("TruckType")
 	// Where filters
 	for _, filter := range filters {
 		builder.Where(filter["field"]+" "+filter["operator"]+" ?", filter["value"])
@@ -57,7 +57,7 @@ func (repository OrderRepository) FindAll(limit int, offset int, filters []map[s
  */
 func (repository OrderRepository) Find(id int) (entities.Order, error) {
 	order := entities.Order{}
-	tx := repository.db.Preload("Destination").Preload("Customer").Preload("Driver").Preload("Driver.TruckType").Preload("TruckType").Find(&order, id)
+	tx := repository.db.Preload("Destination").Preload("Customer").Preload("Driver").Preload("Driver.TruckType").Preload("Driver.User").Preload("TruckType").Find(&order, id)
 	if tx.Error != nil {
 		return entities.Order{}, web.WebError{Code: 500, DevelopmentMessage: "server error", ProductionMessage: "server error"}
 	} else if tx.RowsAffected <= 0 {
@@ -78,7 +78,7 @@ func (repository OrderRepository) Find(id int) (entities.Order, error) {
  */
 func (repository OrderRepository) FindBy(field string, value string) (entities.Order, error) {
 	order := entities.Order{}
-	tx := repository.db.Preload("Destination").Preload("Customer").Preload("Driver").Preload("Driver.TruckType").Preload("TruckType").Where(field+" = ?", value).First(&order)
+	tx := repository.db.Preload("Destination").Preload("Customer").Preload("Driver").Preload("Driver.TruckType").Preload("Driver.User").Preload("TruckType").Where(field+" = ?", value).First(&order)
 	if tx.Error != nil {
 		return entities.Order{}, web.WebError{Code: 500, Message: tx.Error.Error()}
 	} else if tx.RowsAffected <= 0 {
@@ -98,7 +98,7 @@ func (repository OrderRepository) FindBy(field string, value string) (entities.O
  */
 func (repository OrderRepository) FindFirst(filters []map[string]string) (entities.Order, error) {
 	order := entities.Order{}
-	builder := repository.db.Preload("Destination").Preload("Customer").Preload("Driver").Preload("Driver.TruckType").Preload("TruckType")
+	builder := repository.db.Preload("Destination").Preload("Customer").Preload("Driver").Preload("Driver.TruckType").Preload("Driver.User").Preload("TruckType")
 	// Where filters
 	for _, filter := range filters {
 		builder.Where(filter["field"]+" "+filter["operator"]+" ?", filter["value"])

--- a/repositories/order/order_repository_interface.go
+++ b/repositories/order/order_repository_interface.go
@@ -89,7 +89,7 @@ type OrderRepositoryInterface interface {
 	 *
 	 * @return error	error	
 	 */
-	Delete(id int) error
+	Delete(id int, destinationID int) error
 
 	/*
 	 * Delete Batch

--- a/server.go
+++ b/server.go
@@ -10,6 +10,7 @@ import (
 	truckTypeRepository "bringeee-capstone/repositories/truck_type"
 	userRepository "bringeee-capstone/repositories/user"
 	authService "bringeee-capstone/services/auth"
+	orderService "bringeee-capstone/services/order"
 	regionService "bringeee-capstone/services/region"
 	truckTypeService "bringeee-capstone/services/truck_type"
 	userService "bringeee-capstone/services/user"
@@ -51,7 +52,8 @@ func main() {
 	regionHandler := handlers.NewRegionHandler(*regionService)
 	routes.RegisterRegionHandler(e, regionHandler)
 
-	_ = orderRepository.NewOrderRepository(db)
+	orderRepository := orderRepository.NewOrderRepository(db)
+	_ = orderService.NewOrderService(orderRepository)
 
 	e.Logger.Fatal(e.Start(":" + config.App.Port))
 }

--- a/server.go
+++ b/server.go
@@ -7,7 +7,6 @@ import (
 	orderRepository "bringeee-capstone/repositories/order"
 	regionRepository "bringeee-capstone/repositories/region"
 	truckRepository "bringeee-capstone/repositories/truck_type"
-	truckTypeRepository "bringeee-capstone/repositories/truck_type"
 	userRepository "bringeee-capstone/repositories/user"
 	authService "bringeee-capstone/services/auth"
 	orderService "bringeee-capstone/services/order"
@@ -33,13 +32,12 @@ func main() {
 	}))
 
 	userRepository := userRepository.NewUserRepository(db)
-	truckRepository := truckRepository.NewTruckTypeRepository(db)
-	userService := userService.NewUserService(userRepository, truckRepository)
+	truckTypeRepository := truckRepository.NewTruckTypeRepository(db)
+	userService := userService.NewUserService(userRepository, truckTypeRepository)
 	userHandler := handlers.NewUserHandler(userService)
 	routes.RegisterDriverRoute(e, userHandler)
 	routes.RegisterCustomerRoute(e, userHandler)
 
-	truckTypeRepository := truckTypeRepository.NewTruckTypeRepository(db)
 	truckTypeService := truckTypeService.NewTruckTypeService(*truckTypeRepository)
 	truckTypeHandler := handlers.NewTruckTypeHandler(*truckTypeService)
 	routes.RegisterTruckTypeRoute(e, truckTypeHandler)

--- a/services/auth/auth_service.go
+++ b/services/auth/auth_service.go
@@ -57,7 +57,7 @@ func (service AuthService) Login(authReq entities.AuthRequest) (interface{}, err
 		fmt.Println(utils.JsonEncode(driver))
 
 		// Create token
-		token, err := middleware.CreateToken(int(user.ID), userRes.User.Name, userRes.Role)
+		token, err := middleware.CreateToken(int(user.ID), userRes.User.Name, userRes.User.Role)
 		if err != nil {
 			return entities.DriverAuthResponse{}, web.WebError{Code: 500, Message: "Error create token"}
 		}

--- a/services/order/order_service.go
+++ b/services/order/order_service.go
@@ -101,6 +101,31 @@ func (service OrderService) Find(id int) (entities.OrderResponse, error) {
 
 	return orderRes, nil
 }
+
+/*
+ * Find First
+ * -------------------------------
+ * Mengambil order pertama berdasarkan filter yang telah di tentukan pada parameter
+ * dan mengambil data pertama sebagai data order tunggal
+ * @var filter 
+ * @return OrderResponse	order response dalam bentuk tunggal
+ * @return error			error
+ */
+func (service OrderService) FindFirst(filters []map[string]string) (entities.OrderResponse, error) {
+	// Repository call
+	order, err := service.orderRepository.FindFirst(filters)
+	if err != nil {
+		return entities.OrderResponse{}, nil
+	}
+
+	// Convert to response
+	orderRes := entities.OrderResponse{}
+	copier.Copy(&orderRes, &order)
+	copier.Copy(&orderRes, &order.Destination)
+
+	return orderRes, nil
+}
+
 /*
  * Customer Create order
  * -------------------------------

--- a/services/order/order_service.go
+++ b/services/order/order_service.go
@@ -42,12 +42,12 @@ func (service OrderService) FindAll(limit int, page int, filters []map[string]st
 	}
 
 	// Konversi ke order response
-	orderRes := []entities.OrderResponse{}
-	copier.Copy(&orderRes, &orders)
-	for _, order := range orders {
-		copier.Copy(&orderRes, &order.Destination)
+	ordersRes := []entities.OrderResponse{}
+	copier.Copy(&ordersRes, &orders)
+	for i, order := range orders {
+		copier.Copy(&ordersRes[i], &order.Destination)
 	}
-	return orderRes, nil
+	return ordersRes, nil
 }
 /*
  * Get Pagination

--- a/services/order/order_service.go
+++ b/services/order/order_service.go
@@ -3,15 +3,20 @@ package order
 import (
 	"bringeee-capstone/entities"
 	"bringeee-capstone/entities/web"
+	orderRepository "bringeee-capstone/repositories/order"
 	"mime/multipart"
+
+	"github.com/jinzhu/copier"
 )
 
 type OrderService struct {
-	
+	orderRepository orderRepository.OrderRepositoryInterface
 }
 
-func NewOrderService() *OrderService {
-	return &OrderService{}
+func NewOrderService(repository orderRepository.OrderRepositoryInterface) *OrderService {
+	return &OrderService{
+		orderRepository: repository,
+	}
 }
 
 /*
@@ -26,8 +31,23 @@ func NewOrderService() *OrderService {
  * @return order	list order dalam bentuk entity domain
  * @return error	error
  */
-func (service OrderService) FindAll(limit int, offset int, filters []map[string]string, sorts []map[string]interface{}) ([]entities.OrderResponse, error) {
-	panic("implement me")
+func (service OrderService) FindAll(limit int, page int, filters []map[string]string, sorts []map[string]interface{}) ([]entities.OrderResponse, error) {
+	
+	offset := (page - 1) * limit
+
+	// Repository action find all order
+	orders, err := service.orderRepository.FindAll(limit, offset, filters, sorts)
+	if err != nil {
+		return []entities.OrderResponse{}, err
+	}
+
+	// Konversi ke order response
+	orderRes := []entities.OrderResponse{}
+	copier.Copy(&orderRes, &orders)
+	for _, order := range orders {
+		copier.Copy(&orderRes, &order.Destination)
+	}
+	return orderRes, nil
 }
 /*
  * Get Pagination

--- a/services/order/order_service.go
+++ b/services/order/order_service.go
@@ -61,7 +61,23 @@ func (service OrderService) FindAll(limit int, page int, filters []map[string]st
  * @return error	error
  */
 func (service OrderService) GetPagination(limit int, page int, filters []map[string]string) (web.Pagination, error) {
-	panic("implement me")
+	totalRows, err := service.orderRepository.CountAll(filters)
+	if err != nil {
+		return web.Pagination{}, err
+	}
+	var totalPages int64 = 1
+	if limit > 0 {
+		totalPages = totalRows / int64(limit)
+	}
+	if totalPages <= 0 {
+		totalPages = 1
+	}
+	return web.Pagination{
+		Page: page,
+		Limit: limit,
+		TotalPages: int(totalPages),
+		TotalRecords: int(totalRows),
+	}, nil
 }
 /*
  * Find

--- a/services/order/order_service.go
+++ b/services/order/order_service.go
@@ -88,8 +88,18 @@ func (service OrderService) GetPagination(limit int, page int, filters []map[str
  * @return order	order tunggal dalam bentuk response
  * @return error	error
  */
-func (service OrderService) Find(id int) (entities.Order, error) {
-	panic("implement me")
+func (service OrderService) Find(id int) (entities.OrderResponse, error) {
+	order, err := service.orderRepository.Find(id)
+	if err != nil {
+		return entities.OrderResponse{}, err
+	}
+
+	// convert to response
+	orderRes := entities.OrderResponse{}
+	copier.Copy(&orderRes, &order)
+	copier.Copy(&orderRes, &order.Destination)
+
+	return orderRes, nil
 }
 /*
  * Customer Create order


### PR DESCRIPTION
Server order method `find()` `findAll()` `getPagination()`
filename `order_service.go`

Factory Provider Testing code:  
```go
// find by filter
order, _ := orderService.FindFirst([]map[string]string{
	{ "field": "customer_id", "operator": "=", "value": "1" },
})
fmt.Println(utils.JsonEncode(order))

// find by id
order, _ = orderService.Find(11)
fmt.Println(utils.JsonEncode(order))

// pagination
pagination, _ := orderService.GetPagination(50, 1, []map[string]string{
	{ "field": "customer_id", "operator": "=", "value": "1" },
})
fmt.Println(utils.JsonEncode(pagination))

orders, _ := orderService.FindAll(50, 1, []map[string]string{}, []map[string]interface{}{})
fmt.Println(utils.JsonEncode(orders))

```