### PR TITLE
add: order history repository implementation

### DIFF
--- a/repositories/order_history/order_history_repository.go
+++ b/repositories/order_history/order_history_repository.go
@@ -2,8 +2,10 @@ package order_history
 
 import (
 	"bringeee-capstone/entities"
+	"bringeee-capstone/entities/web"
 
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 type OrderHistoryRepository struct {
@@ -26,8 +28,18 @@ func NewOrderHistoryRepository(db *gorm.DB) *OrderHistoryRepository {
  * @return OrderHistory			response payment 
  * @return error 				error
  */
-func (repository OrderHistoryRepository) FindAll(orderID int, sort []map[string]interface{}) ([]entities.OrderHistory, error) {
-	panic("implement me")
+func (repository OrderHistoryRepository) FindAll(orderID int, sorts []map[string]interface{}) ([]entities.OrderHistory, error) {
+	orderHistories := []entities.OrderHistory{}
+	builder := repository.db
+	// OrderBy Filters
+	for _, sort := range sorts {
+		builder.Order(clause.OrderByColumn{Column: clause.Column{Name: sort["field"].(string)}, Desc: sort["desc"].(bool)})
+	}
+	tx := builder.Find(&orderHistories)
+	if tx.Error != nil {
+		return []entities.OrderHistory{}, web.WebError{Code: 500, ProductionMessage: "Server error", DevelopmentMessage: tx.Error.Error()}
+	}
+	return orderHistories, nil
 }
 
 /*
@@ -39,8 +51,17 @@ func (repository OrderHistoryRepository) FindAll(orderID int, sort []map[string]
  * @return OrderHistory			response payment 
  * @return error 				error
  */
-func (repository OrderHistoryRepository) Create(orderID int) (entities.OrderHistory, error) {
-	panic("implement me")
+func (repository OrderHistoryRepository) Create(orderID int, log string, actor string) (entities.OrderHistory, error) {
+	orderHistory := entities.OrderHistory {
+		OrderID: uint(orderID),
+		Log: log,
+		Actor: actor,
+	}
+	tx := repository.db.Create(&orderHistory)
+	if tx.Error != nil {
+		return entities.OrderHistory{}, web.WebError{Code: 500, ProductionMessage: "Server error", DevelopmentMessage: tx.Error.Error()}
+	}
+	return orderHistory, nil
 }
 
 /*
@@ -52,5 +73,9 @@ func (repository OrderHistoryRepository) Create(orderID int) (entities.OrderHist
  * @return error 				error
  */
 func (repository OrderHistoryRepository) Delete(historyID int) error {
-	panic("implement me")
+	tx := repository.db.Delete(&entities.OrderHistory{}, historyID)
+	if tx.Error != nil {
+		return tx.Error
+	}
+	return nil
 }

--- a/repositories/order_history/order_history_repository_interface.go
+++ b/repositories/order_history/order_history_repository_interface.go
@@ -24,7 +24,7 @@ type OrderHistoryRepositoryInterface interface {
 	 * @return OrderHistory			response payment 
 	 * @return error 				error
 	 */
-	 Create(orderID int) (entities.OrderHistory, error)
+	 Create(orderID int, log string, actor string) (entities.OrderHistory, error)
 
 	/*
 	 * Delete history

--- a/server.go
+++ b/server.go
@@ -5,6 +5,7 @@ import (
 	"bringeee-capstone/deliveries/handlers"
 	"bringeee-capstone/deliveries/routes"
 	orderRepository "bringeee-capstone/repositories/order"
+	orderHistoryRepository "bringeee-capstone/repositories/order_history"
 	regionRepository "bringeee-capstone/repositories/region"
 	truckRepository "bringeee-capstone/repositories/truck_type"
 	userRepository "bringeee-capstone/repositories/user"
@@ -56,5 +57,6 @@ func main() {
 	orderRepository := orderRepository.NewOrderRepository(db)
 	_ = orderService.NewOrderService(orderRepository)
 
+	_ = orderHistoryRepository.NewOrderHistoryRepository(db)
 	e.Logger.Fatal(e.Start(":" + config.App.Port))
 }


### PR DESCRIPTION
Added order history repository provider
Sample test code on factory provider `server.go`
```go
orderHistoryRepository := orderHistoryRepository.NewOrderHistoryRepository(db)
orderHistoryRepository.Create(11, "Created order", "customer") // OrderID: 11
orderHistoryRepository.Delete(1) // HistoryID: 1

orderHistories, _ := orderHistoryRepository.FindAll(11, []map[string]interface{}{}) // OrderID: 11
fmt.Println(utils.JsonEncode(orderHistories))
```