### PR TITLE
feat: admin set fixed price, confirm and cancel order

### DIFF
--- a/deliveries/handlers/admin_handler.go
+++ b/deliveries/handlers/admin_handler.go
@@ -509,7 +509,7 @@ func (handler AdminHandler) ListOrders(c echo.Context) error {
 }
 
 /*
- * Driver - Detail order
+ * Admin - Detail order
  * ------------------------------------
  * Mendapatkan detail order
  * GET /api/order/{orderID}
@@ -561,5 +561,62 @@ func (handler AdminHandler) DetailOrder(c echo.Context) error {
 		Error: nil,
 		Links: links,
 		Data: orderRes,
+	})
+}
+
+/*
+ * Admin - Set fixed price
+ * ------------------------------------
+ * Mendapatkan detail order
+ * PATCH /api/order/{orderID}
+ */
+func (handler AdminHandler) SetFixedPrice(c echo.Context) error {
+	links := map[string]string{}
+	orderID, err := strconv.Atoi(c.Param("orderID"))
+	links["self"] = fmt.Sprintf("%s/api/orders/%s", configs.Get().App.BaseURL, c.Param("orderID"))
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, web.ErrorResponse{
+			Status: "ERROR",
+			Code: http.StatusBadRequest,
+			Error: "Invalid order id parameter",
+			Links: links,
+		})
+	}
+	_, role, err := middleware.ReadToken(c.Get("user"))
+	if err != nil {
+		return c.JSON(http.StatusUnauthorized, web.ErrorResponse{
+			Status: "ERROR",
+			Code: http.StatusUnauthorized,
+			Error: "Unauthorized user",
+			Links: links,
+		})
+	}
+
+	// reject if not admin
+	if role != "admin" {
+		return c.JSON(http.StatusUnauthorized, web.ErrorResponse{
+			Status: "ERROR",
+			Code: http.StatusUnauthorized,
+			Error: "Unauthorized user",
+			Links: links,
+		})
+	}
+
+	// service action
+	setPriceReq := entities.AdminSetPriceOrderRequest{}
+	c.Bind(&setPriceReq)
+	err = handler.orderService.SetFixOrder(orderID, setPriceReq)
+	if err != nil {
+		return helpers.WebErrorResponse(c, err, links)
+	}
+
+	return c.JSON(http.StatusOK, web.SuccessResponse{
+		Status: "OK",
+		Code: http.StatusOK,
+		Error: nil,
+		Links: links,
+		Data: map[string]interface{} {
+			"id": orderID,
+		},
 	})
 }

--- a/deliveries/handlers/admin_handler.go
+++ b/deliveries/handlers/admin_handler.go
@@ -675,3 +675,58 @@ func (handler AdminHandler) ConfirmOrder(c echo.Context) error {
 		},
 	})
 }
+
+/*
+ * Admin - Cancel order
+ * ------------------------------------
+ * Mendapatkan detail order
+ * POST /api/order/{orderID}/confirm
+ */
+func (handler AdminHandler) CancelOrder(c echo.Context) error {
+	links := map[string]string{}
+	orderID, err := strconv.Atoi(c.Param("orderID"))
+	links["self"] = fmt.Sprintf("%s/api/orders/%s/cancel", configs.Get().App.BaseURL, c.Param("orderID"))
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, web.ErrorResponse{
+			Status: "ERROR",
+			Code: http.StatusBadRequest,
+			Error: "Invalid order id parameter",
+			Links: links,
+		})
+	}
+	userID, role, err := middleware.ReadToken(c.Get("user"))
+	if err != nil {
+		return c.JSON(http.StatusUnauthorized, web.ErrorResponse{
+			Status: "ERROR",
+			Code: http.StatusUnauthorized,
+			Error: "Unauthorized user",
+			Links: links,
+		})
+	}
+
+	// reject if not admin
+	if role != "admin" {
+		return c.JSON(http.StatusUnauthorized, web.ErrorResponse{
+			Status: "ERROR",
+			Code: http.StatusUnauthorized,
+			Error: "Unauthorized user",
+			Links: links,
+		})
+	}
+
+	// service action
+	err = handler.orderService.CancelOrder(orderID, userID, map[string]bool{"admin": true, "": false}[role])
+	if err != nil {
+		return helpers.WebErrorResponse(c, err, links)
+	}
+
+	return c.JSON(http.StatusOK, web.SuccessResponse{
+		Status: "OK",
+		Code: http.StatusOK,
+		Error: nil,
+		Links: links,
+		Data: map[string]interface{} {
+			"id": orderID,
+		},
+	})
+}

--- a/deliveries/routes/route.go
+++ b/deliveries/routes/route.go
@@ -40,6 +40,7 @@ func RegisterAdminRoute(e *echo.Echo, AdminHandler *handlers.AdminHandler) {
 	order := e.Group("/api/orders", middleware.JWTMiddleware())
 	order.GET("", AdminHandler.ListOrders)
 	order.GET("/:orderID", AdminHandler.DetailOrder)
+	order.PATCH("/:orderID", AdminHandler.SetFixedPrice)
 	order.GET("/:orderID/histories", AdminHandler.DetailOrderHistory)
 }
 

--- a/deliveries/routes/route.go
+++ b/deliveries/routes/route.go
@@ -42,6 +42,7 @@ func RegisterAdminRoute(e *echo.Echo, AdminHandler *handlers.AdminHandler) {
 	order.GET("/:orderID", AdminHandler.DetailOrder)
 	order.PATCH("/:orderID", AdminHandler.SetFixedPrice)
 	order.POST("/:orderID/confirm", AdminHandler.ConfirmOrder)
+	order.POST("/:orderID/cancel", AdminHandler.CancelOrder)
 	order.GET("/:orderID/histories", AdminHandler.DetailOrderHistory)
 }
 

--- a/deliveries/routes/route.go
+++ b/deliveries/routes/route.go
@@ -41,6 +41,7 @@ func RegisterAdminRoute(e *echo.Echo, AdminHandler *handlers.AdminHandler) {
 	order.GET("", AdminHandler.ListOrders)
 	order.GET("/:orderID", AdminHandler.DetailOrder)
 	order.PATCH("/:orderID", AdminHandler.SetFixedPrice)
+	order.POST("/:orderID/confirm", AdminHandler.ConfirmOrder)
 	order.GET("/:orderID/histories", AdminHandler.DetailOrderHistory)
 }
 

--- a/deliveries/validations/order_validation.go
+++ b/deliveries/validations/order_validation.go
@@ -36,6 +36,7 @@ var orderErrorMessages = map[string]string{
 	"TruckTypeID|required"				: "truck type id is required",
 	"TotalVolume|required"				: "total volume is required",
 	"TotalWeight|required"				: "total weight is required",
+	"FixedPrice|required"				: "fixed price is required",
 }
 
 /*
@@ -73,6 +74,20 @@ func ValidateCustomerCreateOrderRequest(validate *validator.Validate, customerCr
 	validateOrderStruct(validate, customerCreateOrderReq, orderErrorMessages, &errors)
 	validateOrderFiles(files, orderFileSizeRules, orderFileExtRules, &errors)
 
+	if len(errors) > 0 {
+		return web.ValidationError{
+			Code:               400,
+			ProductionMessage:  "Validation error",
+			DevelopmentMessage: "Validation error",
+			Errors:             errors,
+		}
+	}
+	return nil
+}
+
+func ValidateAdminSetPriceOrderRequest(validate *validator.Validate, adminSetPriceOrderReq entities.AdminSetPriceOrderRequest) error {
+	errors := []web.ValidationErrorItem{}
+	validateOrderStruct(validate, adminSetPriceOrderReq, orderErrorMessages, &errors)
 	if len(errors) > 0 {
 		return web.ValidationError{
 			Code:               400,

--- a/entities/order.go
+++ b/entities/order.go
@@ -136,7 +136,7 @@ type OrderResponse struct {
 	TotalWeight int	`json:"total_weight"`
 	Distance int	`json:"distance"`
 	EstimatedPrice int64	`json:"estimated_price"`
-	FixedPrice int64	`json:"fixed_price"`
+	FixPrice int64	`json:"fix_price"`
 	TransactionID interface{}	`json:"transaction_id"`
 	Status string	`json:"status"`
 	Description string	`json:"description"`

--- a/services/order/order_service.go
+++ b/services/order/order_service.go
@@ -255,6 +255,11 @@ func (service OrderService) ConfirmOrder(orderID int, userID int, isAdmin bool) 
 		return err
 	}
 
+	// set fix price = estimated price if fix price empty
+	if order.FixPrice <= 0 {
+		order.FixPrice = order.EstimatedPrice
+	}
+
 	// reject if status other than requested
 	if order.Status != "REQUESTED" {
 		return web.WebError{

--- a/services/order/order_service_interface.go
+++ b/services/order/order_service_interface.go
@@ -72,9 +72,10 @@ type OrderServiceInterface interface {
 	 * -------------------------------
 	 * Set fixed price order oleh admin untuk diteruskan kembali ke user agar di konfirmasi/cancel
 	 * @var orderRequest		request create order oleh customer
+	 * @var orderID				orderID
 	 * @return OrderResponse	order response 
 	 */
-	SetFixOrder(setPriceRequest entities.AdminSetPriceOrderRequest) error 
+	SetFixOrder(orderID int, setPriceRequest entities.AdminSetPriceOrderRequest) error 
 
 	/*
 	 * Confirm Order


### PR DESCRIPTION
## Set Fixed Price
> Endpoint: `PATCH` `/api/orders/{orderID}`
> Sample Body: `{ "fixed_price": "800000" }`   - content type: `application/x-www-form-urlencoded`

**Response success + added to tracking history order**
![image](https://user-images.githubusercontent.com/13761315/165904519-8cdecfe9-160e-4e9a-8aa3-31e939838a99.png)
history (`GET` `/api/orders/{orderID}/histories`)
![image](https://user-images.githubusercontent.com/13761315/165904756-b1eaacd0-d46a-43f4-8235-4c396a8efa07.png)


**Invalid order parameter**
![image](https://user-images.githubusercontent.com/13761315/165904652-36c1632c-71bf-40d3-9241-2dd210bfa78d.png)


**Response when order status has passed through confirmation**
![image](https://user-images.githubusercontent.com/13761315/165904415-99ebbf93-322e-4ffe-99f9-06bfe392dc02.png)

## Confirm Order
> Endpoint: `POST` `/api/orders/{orderID}/confirm`
> _Confirmation can only happened to order with `REQUESTED` status, `fix_price` value follows the existing `fix_price` if it exists, otherwise fix price use the earlier `estimated_price`_

**Success**
![image](https://user-images.githubusercontent.com/13761315/165905051-7ba2a059-5af2-4304-9878-c558c8df081b.png)
history (`GET` `/api/orders/{orderID}/histories`)
![image](https://user-images.githubusercontent.com/13761315/165905185-747e215c-5ff6-4185-8239-0a3ca41393b5.png)

**Invalid order status**
![image](https://user-images.githubusercontent.com/13761315/165905811-465f38cb-2073-4395-b376-49d31fa5606a.png)

**Invalid order param**
![image](https://user-images.githubusercontent.com/13761315/165905860-30997ad6-7f16-4554-a542-6bea56aedc54.png)

## Cancel Order

> Same thing with confirm order but with different endpoint
> Endpoint: POST /api/orders/{orderID}/confirm
> Cancellation can only happened to order with `REQUESTED` or `CONFIRMED` status