### PR TITLE
feat: cancel established payment

### DIFF
--- a/deliveries/handlers/customer_handler.go
+++ b/deliveries/handlers/customer_handler.go
@@ -663,3 +663,70 @@ func (handler CustomerHandler) GetPayment(c echo.Context) error {
 		Data: paymentRes,
 	})
 }
+
+
+/* 
+ * Customer - Cancel payment order
+ * ---------------------------------
+ * Mendapatkan detail pembayaran untuk order yang sudah dibuatkan payment
+ * GET /api/customers/orders/{orderID}/payment/cancel
+ */
+func (handler CustomerHandler) CancelPayment(c echo.Context) error {
+	orderID, err := strconv.Atoi(c.Param("orderID"))
+	links := map[string]string{}
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, web.ErrorResponse{
+			Status: "ERROR",
+			Code: http.StatusBadRequest,
+			Error: "Invalid order id parameter",
+			Links: links,
+		})
+	}
+	links["self"] = fmt.Sprintf("%s/api/customers/orders/%s/payment/cancel", configs.Get().App.BaseURL, c.Param("orderID"))
+
+	// check if authenticated user is a customer
+	userID, role, err := middleware.ReadToken(c.Get("user"))
+	if err != nil {
+		return c.JSON(http.StatusUnauthorized, web.ErrorResponse{
+			Status: "ERROR",
+			Code: http.StatusUnauthorized,
+			Error: "Unauthorized user",
+			Links: links,
+		})
+	}
+	if role != "customer" {
+		return c.JSON(http.StatusUnauthorized, web.ErrorResponse{
+			Status: "ERROR",
+			Code: http.StatusUnauthorized,
+			Error: "Unauthorized user",
+			Links: links,
+		})
+	}
+	// reject if order belong to someone else
+	order, err := handler.orderService.Find(orderID)
+	if err != nil {
+		return helpers.WebErrorResponse(c, err, links)
+	}
+	if int(order.CustomerID) != userID {
+		return c.JSON(http.StatusUnauthorized, web.ErrorResponse{
+			Status: "ERROR",
+			Code: http.StatusUnauthorized,
+			Error: "This order doesn't belong to currently authenticated user",
+			Links: links,
+		})
+	}
+	// service payment action
+	err = handler.orderService.CancelPayment(orderID)
+	if err != nil {
+		return helpers.WebErrorResponse(c, err, links)
+	}
+	return c.JSON(http.StatusOK, web.SuccessResponse{
+		Status: "OK",
+		Code: http.StatusOK,
+		Error: nil,
+		Links: links,
+		Data: map[string]interface{}{
+			"id": orderID,
+		},
+	})
+}

--- a/deliveries/routes/route.go
+++ b/deliveries/routes/route.go
@@ -14,14 +14,15 @@ func RegisterCustomerRoute(e *echo.Echo, customerHandler *handlers.CustomerHandl
 	group.DELETE("", customerHandler.DeleteCustomer, middleware.JWTMiddleware()) // delete customer
 
 	order := e.Group("/api/customers/orders", middleware.JWTMiddleware())
+	order.GET("", customerHandler.ListOrders)
 	order.POST("", customerHandler.CreateOrder)
+	order.GET("/:orderID", customerHandler.DetailOrder)
+	order.GET("/:orderID/histories", customerHandler.DetailOrderHistory)
 	order.POST("/:orderID/confirm", customerHandler.ConfirmOrder)
 	order.POST("/:orderID/cancel", customerHandler.CancelOrder)
-	order.GET("", customerHandler.ListOrders)
-	order.GET("/:orderID", customerHandler.DetailOrder)
-	order.GET("/:orderID/payment", customerHandler.GetPayment)
 	order.POST("/:orderID/payment", customerHandler.CreatePayment)
-	order.GET("/:orderID/histories", customerHandler.DetailOrderHistory)
+	order.GET("/:orderID/payment", customerHandler.GetPayment)
+	order.POST("/:orderID/payment/cancel", customerHandler.CancelPayment)
 }
 
 func RegisterDriverRoute(e *echo.Echo, driverHandler *handlers.DriverHandler) {

--- a/repositories/payment/midtrans_payment_repository.go
+++ b/repositories/payment/midtrans_payment_repository.go
@@ -449,3 +449,16 @@ func (repository MidtransPaymentRepository) GetPaymentStatus(transactionID strin
 	}
 	return paymentRes, nil
 }
+
+/*
+* Cancel payment
+* -------------------------------
+* Membatalkan data transaksi berdasarkan `transaction_id`
+*
+* @var transaction_id		Transaction ID
+* @return PaymentResponse	Response
+*/
+func (repository MidtransPaymentRepository) CancelPayment(transactionID string, paymentMethod string) error {
+
+	return nil
+}

--- a/repositories/payment/payment_repository_interface.go
+++ b/repositories/payment/payment_repository_interface.go
@@ -65,4 +65,14 @@ type PaymentRepositoryInterface interface {
 	* @return PaymentResponse	Response
 	*/
 	GetPaymentStatus(transactionID string, paymentMethod string) (entities.PaymentResponse, error)
+
+	/*
+	* Cancel payment
+	* -------------------------------
+	* Membatalkan data transaksi berdasarkan `transaction_id`
+	*
+	* @var transaction_id		Transaction ID
+	* @return PaymentResponse	Response
+	*/
+	CancelPayment(transactionID string, paymentMethod string) error
 }

--- a/server.go
+++ b/server.go
@@ -62,26 +62,5 @@ func main() {
 	routes.RegisterCustomerRoute(e, customerHandler, orderHandler)
 	routes.RegisterCustomerRoute(e, customerHandler, orderHandler)
 
-	// err := orderService.ConfirmOrder(1, 2, false)
-	// fmt.Println(err)
-
-	// data, err := orderService.CreatePayment(5, entities.CreatePaymentRequest{ PaymentMethod: "BANK_TRANSFER_MANDIRI" })
-	// if err != nil {
-	// 	fmt.Println(utils.JsonEncode(err))
-	// }
-	// fmt.Println(utils.JsonEncode(data))
-	// fmt.Println(utils.JsonEncode(configs.Get().Payment.MidtransServerKey))	
-	
-	// paymentRes, _ := midtransPaymentRepository.GetPaymentStatus("4da46a8a-b133-4ec2-b23c-76f795245018", "BANK_TRANSFER_MANDIRI")
-	// fmt.Println(utils.JsonEncode(paymentRes))
-	// paymentRes, _ = midtransPaymentRepository.GetPaymentStatus("80da96ea-ce20-45eb-a89f-320759d41272", "BANK_TRANSFER_BRI")
-	// fmt.Println(utils.JsonEncode(paymentRes))
-	// paymentRes, _ = midtransPaymentRepository.GetPaymentStatus("83d81c00-8eb5-4de1-8450-7d57bfb52ecc", "BANK_TRANSFER_BNI")
-	// fmt.Println(utils.JsonEncode(paymentRes))
-	// paymentRes, _ = midtransPaymentRepository.GetPaymentStatus("01072be0-cd5a-4dfc-a63a-d9c199f0cb94", "BANK_TRANSFER_PERMATA")
-	// fmt.Println(utils.JsonEncode(paymentRes))
-	// paymentRes, _ = midtransPaymentRepository.GetPaymentStatus("51e3a2a7-fe69-44be-875e-0d75df142299", "BANK_TRANSFER_BCA")
-	// fmt.Println(utils.JsonEncode(paymentRes))
-	
 	e.Logger.Fatal(e.Start(":" + config.App.Port))
 }

--- a/services/order/order_service.go
+++ b/services/order/order_service.go
@@ -473,6 +473,14 @@ func (service OrderService) CancelPayment(orderID int) error {
 	if err != nil {
 		return err
 	}
+	// update order
+	order.DriverID = null.IntFromPtr(nil)
+	order.PaymentMethod = ""
+	order.TransactionID = ""
+	_, err = service.orderRepository.Update(order, orderID)
+	if err != nil {
+		return web.WebError{ Code: 500, ProductionMessage: "Failed to update order data", DevelopmentMessage: "update order fail:" + err.Error() }
+	}
 	return nil
 }
 

--- a/services/order/order_service.go
+++ b/services/order/order_service.go
@@ -452,6 +452,17 @@ func (service OrderService) GetPayment(orderID int) (entities.PaymentResponse, e
 }
 
 /*
+ * Cancel Order payment
+ * -------------------------------
+ * Cancel payment order yang sudah dibuat
+ * @var orderID 	order id terkait
+ * @return 			error
+ */
+func (service OrderService) CancelPayment(orderID int) error {
+	return nil
+}
+
+/*
  * Find All History
  * -------------------------------
  * Mengambil data order berdasarkan filters dan sorts

--- a/services/order/order_service.go
+++ b/services/order/order_service.go
@@ -468,6 +468,14 @@ func (service OrderService) CancelPayment(orderID int) error {
 	if order.Status != "CONFIRMED" {
 		return web.WebError{ Code: 400, Message: "Order hasn't been confirmed or already been paid"}
 	}
+	// reject if transaction_id is empty
+	if order.TransactionID == "" {
+		return web.WebError{
+			Code:    400,
+			Message: "Payment transaction hasn't been created or already been cancelled",
+		}
+	}
+
 	// repository action
 	err = service.paymentRepository.CancelPayment(order.TransactionID, order.PaymentMethod)
 	if err != nil {

--- a/services/order/order_service.go
+++ b/services/order/order_service.go
@@ -459,6 +459,20 @@ func (service OrderService) GetPayment(orderID int) (entities.PaymentResponse, e
  * @return 			error
  */
 func (service OrderService) CancelPayment(orderID int) error {
+	// get order
+	order, err := service.orderRepository.Find(orderID)
+	if err != nil {
+		return nil
+	}
+	// reject if status is other than confirmed
+	if order.Status != "CONFIRMED" {
+		return web.WebError{ Code: 400, Message: "Order hasn't been confirmed or already been paid"}
+	}
+	// repository action
+	err = service.paymentRepository.CancelPayment(order.TransactionID, order.PaymentMethod)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/services/order/order_service_interface.go
+++ b/services/order/order_service_interface.go
@@ -115,6 +115,15 @@ type OrderServiceInterface interface {
 	 * @return PaymentResponse		response payment 
 	 */
 	GetPayment(orderID int) (entities.PaymentResponse, error)
+
+	/*
+	 * Cancel Order payment
+	 * -------------------------------
+	 * Cancel payment order yang sudah dibuat
+	 * @var orderID 	order id terkait
+	 * @return 			error
+	 */
+	CancelPayment(orderID int) error
 	
 	/*
 	 * Find All History


### PR DESCRIPTION
### Cancel payment
> endpoint: `POST` `/api/customers/orders/{orderID}/payment/cancel`
> _Successful response will set order's `transaction_id` to `empty string` and set payment to cancelled on third party service_

Successful response
![image](https://user-images.githubusercontent.com/13761315/166119802-3085f9fd-48af-4b94-9896-91b575a98baf.png)

Empty/cancelled payment state
![image](https://user-images.githubusercontent.com/13761315/166119920-57586e28-ac66-450c-a54a-be08fdf5edc4.png)

Invalid param
![image](https://user-images.githubusercontent.com/13761315/166119935-87b6dfb9-b6e9-42e0-933c-a19e528a8295.png)

False order ownership
![image](https://user-images.githubusercontent.com/13761315/166119983-bc01dbae-38c4-43ca-a809-a1a1d04d133e.png)

