### PR TITLE
feat: midtrans payment webhook endpoint implementation

### DIFF
--- a/deliveries/handlers/payment_handler.go
+++ b/deliveries/handlers/payment_handler.go
@@ -1,0 +1,71 @@
+package handlers
+
+import (
+	"bringeee-capstone/configs"
+	"bringeee-capstone/deliveries/helpers"
+	"bringeee-capstone/entities/web"
+	orderService "bringeee-capstone/services/order"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/labstack/echo/v4"
+)
+
+type PaymentHandler struct {
+	orderService orderService.OrderServiceInterface
+}
+
+func NewPaymentHandler(orderService orderService.OrderServiceInterface) *PaymentHandler {
+	return &PaymentHandler{
+		orderService: orderService,
+	}
+}
+
+
+/*
+ * Midtrans Payment notification Webhook
+ * -------------------------------
+ * Payment Webhook notification, dikirimkan oleh layanan pihak ketiga
+ * referensi: https://docs.midtrans.com/en/after-payment/http-notification
+ * endpoint: POST /api/payments/midtrans_webhook
+ */
+func (handler PaymentHandler) MidtransWebhook(c echo.Context) error {
+	links := map[string]string{}	
+	links["self"] = fmt.Sprintf("%s/api/payments/midtrans_webhook", configs.Get().App.BaseURL)
+
+	trStatus := c.FormValue("transaction_status")
+	if trStatus == "" {
+		return c.JSON(http.StatusBadRequest, web.ErrorResponse{
+			Status: "ERROR",
+			Code: http.StatusBadRequest,
+			Error: "transaction status must be provided",
+			Links: links,
+		})
+	}
+	orderID, err := strconv.Atoi(c.FormValue("order_id"))
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, web.ErrorResponse{
+			Status: "ERROR",
+			Code: http.StatusBadRequest,
+			Error: "order id request body is invalid",
+			Links: links,
+		})
+	}
+
+	// service call
+	err = handler.orderService.PaymentWebhook(orderID, trStatus)
+	if err != nil {
+		return helpers.WebErrorResponse(c, err, links)
+	}
+
+	return c.JSON(http.StatusOK, web.SuccessResponse{
+		Status: "OK",
+		Code: http.StatusOK,
+		Error: nil,
+		Links: links,
+		Data: map[string]interface{}{
+			"id": orderID,
+		},
+	})
+}

--- a/deliveries/routes/route.go
+++ b/deliveries/routes/route.go
@@ -67,3 +67,7 @@ func RegisterRegionHandler(e *echo.Echo, regionHandler *handlers.RegionHandler) 
 	e.GET("/api/provinces/:provinceID/cities", regionHandler.IndexCity)
 	e.GET("/api/provinces/:provinceID/cities/:cityID/districts", regionHandler.IndexDistrict)
 }
+
+func RegisterPaymentRoute(e *echo.Echo, paymentHandler *handlers.PaymentHandler) {
+	e.POST("/api/payments/midtrans_webhook", paymentHandler.MidtransWebhook)
+}

--- a/server.go
+++ b/server.go
@@ -53,6 +53,7 @@ func main() {
 	truckTypeHandler := handlers.NewTruckTypeHandler(*truckTypeService)
 	regionHandler := handlers.NewRegionHandler(regionService)
 	orderHandler := handlers.NewOrderHandler(orderService, userService)
+	paymentHandler := handlers.NewPaymentHandler(orderService)
 
 	routes.RegisterDriverRoute(e, driverHandler)
 	routes.RegisterAdminRoute(e, adminHandler)
@@ -61,6 +62,7 @@ func main() {
 	routes.RegisterRegionHandler(e, regionHandler)
 	routes.RegisterCustomerRoute(e, customerHandler, orderHandler)
 	routes.RegisterCustomerRoute(e, customerHandler, orderHandler)
+	routes.RegisterPaymentRoute(e, paymentHandler)
 
 	e.Logger.Fatal(e.Start(":" + config.App.Port))
 }

--- a/services/order/order_service.go
+++ b/services/order/order_service.go
@@ -525,6 +525,19 @@ func (service OrderService) FindAllHistory(orderID int, sorts []map[string]inter
  * @return error	error
  */
 func (service OrderService) PaymentWebhook(orderID int, status string) error {
+	order, err := service.orderRepository.Find(orderID)
+	if err != nil {
+		return err
+	}
+	if status == "settlement" {
+		// if status settlement, set order to MANIFESTED
+	 	order.Status = "MANIFESTED"
+	} 
+	order.DriverID = null.IntFromPtr(nil)
+	_, err = service.orderRepository.Update(order, orderID)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/services/order/order_service.go
+++ b/services/order/order_service.go
@@ -520,19 +520,12 @@ func (service OrderService) FindAllHistory(orderID int, sorts []map[string]inter
  * Payment Webhook notification, dikirimkan oleh layanan pihak ketiga
  * referensi: https://docs.midtrans.com/en/after-payment/http-notification
  *
- * @var limit 	batas limit hasil query
- * @var offset 	offset hasil query
- * @var filters	query untuk penyaringan data, { field, operator, value }
- * @var sorts	pengurutan data, { field, value[bool] }
- * @return order	list order dalam bentuk entity domain
+ * @var order 		order id
+ * @var status 		payment status
  * @return error	error
  */
-func (service OrderService) PaymentWebhook(orderID int) error {
-
-	// if status settlement, set order to MANIFESTED
-	// if status is deny, cancel, expire, set to CANCELLED
-
-	panic("implement me")
+func (service OrderService) PaymentWebhook(orderID int, status string) error {
+	return nil
 }
 
 /*

--- a/services/order/order_service_interface.go
+++ b/services/order/order_service_interface.go
@@ -144,10 +144,11 @@ type OrderServiceInterface interface {
 	 * Payment Webhook notification, dikirimkan oleh layanan pihak ketiga
 	 * referensi: https://docs.midtrans.com/en/after-payment/http-notification
 	 *
-	 * @var orer 		order id
+	 * @var order 		order id
+	 * @var status 		payment status
 	 * @return error	error
 	 */
-	PaymentWebhook(orderID int) error
+	PaymentWebhook(orderID int, status string) error
 
 	/*
 	 * Take order for shipping


### PR DESCRIPTION
### Webhook midtrans payment notification system
> endpoint: `POST` `/api/payments/midtrans_webhook`
> can be tested locally, but ideally this can be tested on production after merge involving midtrans for integration testing

Success response
![image](https://user-images.githubusercontent.com/13761315/166121003-16b06d0d-ea49-4b81-9e82-5663ce96c073.png)
